### PR TITLE
Add support for choosing listening host for Flask

### DIFF
--- a/backend/app/web_server.py
+++ b/backend/app/web_server.py
@@ -61,10 +61,11 @@ class EndpointAction:
     return self.response
 
 class Server(object):
-  def __init__(self, app, port=4567, auth_key=""):
+  def __init__(self, app, host='127.0.0.1', port=4567, auth_key=""):
     self.app = app
     self.server = None
     self.port = port
+    self.host = host
     self.auth_key = auth_key
     self.flask = Flask(__name__,
         static_folder='../static',
@@ -85,7 +86,7 @@ class Server(object):
     self.init()
 
   def start(self):
-    self.flask.run(port=self.port, threaded=True) #, debug=True)
+    self.flask.run(host=self.host, port=self.port, threaded=True) #, debug=True)
 
   def add(self, url, handler, methods=['POST'], **kwargs):
     name = kwargs['name'] if 'name' in kwargs else None

--- a/backend/main.py
+++ b/backend/main.py
@@ -34,6 +34,7 @@ class App:
     
     self.log("* Initializing webserver")
     self.server = web_server.Server(self,
+      host=self.config.get('server_host', '127.0.0.1')),
       port=int(self.config.get('server_port', '4567')),
       auth_key=self.config.get('auth_key', ''), 
     )

--- a/sample/config-sample.toml
+++ b/sample/config-sample.toml
@@ -1,6 +1,7 @@
 # If you make the app externally accessible, you should set a good
 # secret key.
 #auth_key = 'my s3cret k33y'
+server_host = 127.0.0.1
 server_port = 4742
 log_level = 3
 


### PR DESCRIPTION
If the server is on a remote machine, allows to set a listening ip/hostname, otherwise, only runs on 127.0.0.1.
Set it by default to 127.0.0.1 for security